### PR TITLE
Update Update MtouchExtraArgs

### DIFF
--- a/eContainment4.iOS/eContainment4.iOS.csproj
+++ b/eContainment4.iOS/eContainment4.iOS.csproj
@@ -27,7 +27,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchExtraArgs>–registrar:static</MtouchExtraArgs>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
More info here on Type Registrar: https://docs.microsoft.com/en-us/xamarin/ios/internals/registrar 

Dynamic Registrar is the default for simulators, but the AppDynamics.Agent Xamarin package requires static registrar. 

<img width="1792" alt="Screenshot 2022-03-04 at 15 16 43" src="https://user-images.githubusercontent.com/26183235/156770194-65c47e54-b0e6-4ce0-8a39-0e4d410c73ca.png">



[![Build status](https://build.appcenter.ms/v0.1/apps/1d784438-7e3f-4711-a16b-6ee429696c52/branches/appd-ios-fix/badge)](https://appcenter.ms)


